### PR TITLE
Update for use with NVR Beta software 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ Hopefully this is enough to get you going::
     -v, --verbose
     -d, --dump
     -u UUID, --uuid=UUID  Camera UUID
+    -i id, --id=id        Camera Connection id
+    -c, --connect_with_id Connect using id instead of UUID (NVR Beta API)
     --name=NAME           Camera name
     -l, --list
     --recordmode=RECORDMODE

--- a/uvcclient/main.py
+++ b/uvcclient/main.py
@@ -58,12 +58,12 @@ def do_set_password(opts):
     if password1 != password2:
         print('Passwords do not match')
         return
-    INFO_STORE.set_camera_password(opts.uuid, password1)
+    INFO_STORE.set_camera_password(opts.connection_id, password1)
     print('Password set')
 
 
 def main():
-    host, port, apikey, path = nvr.get_auth_from_env()
+    host, port, apikey, path, connect_with_id = nvr.get_auth_from_env()
 
     parser = optparse.OptionParser()
     parser.add_option('-H', '--host', default=host,
@@ -72,6 +72,8 @@ def main():
                       help='UVC Port')
     parser.add_option('-K', '--apikey', default=apikey,
                       help='UVC API Key')
+    parser.add_option('-cid', '--connect_with_id', default=connect_with_id,
+                      help='Connect with _id instead of uuid')
     parser.add_option('-v', '--verbose', action='store_true', default=False)
     parser.add_option('-d', '--dump', action='store_true', default=False)
     parser.add_option('-u', '--uuid', default=None, help='Camera UUID')
@@ -113,13 +115,13 @@ def main():
     client = nvr.UVCRemote(opts.host, opts.port, opts.apikey)
 
     if opts.name:
-        opts.uuid = client.name_to_uuid(opts.name)
-        if not opts.uuid:
+        opts.connection_id = client.name_to_connection_id(opts.name)
+        if not opts.connection_id:
             print('`%s\' is not a valid name' % opts.name)
             return
 
     if opts.dump:
-        client.dump(opts.uuid)
+        client.dump(opts.connection_id)
     elif opts.list:
         for cam in client.index():
             if not cam['managed']:
@@ -136,18 +138,18 @@ def main():
                 status = 'unknown:%s' % cam['state']
             print('%s: %-24.24s [%10s]' % (cam['uuid'], cam['name'], status))
     elif opts.recordmode:
-        if not opts.uuid:
+        if not opts.connection_id:
             print('Name or UUID is required')
             return 1
 
-        r = client.set_recordmode(opts.uuid, opts.recordmode,
+        r = client.set_recordmode(opts.connection_id, opts.recordmode,
                                   opts.recordchannel)
         if r is True:
             return 0
         else:
             return 1
     elif opts.get_picture_settings:
-        settings = client.get_picture_settings(opts.uuid)
+        settings = client.get_picture_settings(opts.connection_id)
         print(','.join(['%s=%s' % (k, v) for k, v in settings.items()]))
         return 0
     elif opts.set_picture_settings:
@@ -160,7 +162,7 @@ def main():
             print('Invalid picture setting string format')
             return 1
         try:
-            result = client.set_picture_settings(opts.uuid, settings)
+            result = client.set_picture_settings(opts.connection_id, settings)
         except Invalid as e:
             print('Invalid value: %s' % e)
             return 1
@@ -169,7 +171,7 @@ def main():
                 print('Rejected: %s' % k)
         return 0
     elif opts.set_led is not None:
-        camera = client.get_camera(opts.uuid)
+        camera = client.get_camera(opts.connection_id)
         if not camera:
             print('No such camera')
             return 1
@@ -178,19 +180,19 @@ def main():
             return 2
         do_led(camera, opts.set_led.lower() == 'on')
     elif opts.prune_zones:
-        if not opts.uuid:
+        if not opts.connection_id:
             print('Name or UUID is required')
             return 1
-        client.prune_zones(opts.uuid)
+        client.prune_zones(opts.connection_id)
     elif opts.list_zones:
-        if not opts.uuid:
+        if not opts.connection_id:
             print('Name or UUID is required')
             return 1
-        zones = client.list_zones(opts.uuid)
+        zones = client.list_zones(opts.connection_id)
         for zone in zones:
             print(zone['name'])
     elif opts.get_snapshot:
-        camera = client.get_camera(opts.uuid)
+        camera = client.get_camera(opts.connection_id)
         if not camera:
             print('No such camera')
             return 1

--- a/uvcclient/nvr.py
+++ b/uvcclient/nvr.py
@@ -51,11 +51,11 @@ class UVCRemote(object):
     """Remote control client for Ubiquiti Unifi Video NVR."""
     CHANNEL_NAMES = ['high', 'medium', 'low']
 
-    def __init__(self, host, port, apikey, path='/', uuid_connection='true'):
+    def __init__(self, host, port, apikey, path='/', id_connection=False):
         self._host = host
         self._port = port
         self._path = path
-        self.uuid_connection = uuid_connection
+        self.id_connection = id_connection
         if path != '/':
             raise Invalid('Path not supported yet')
         self._apikey = apikey
@@ -206,10 +206,11 @@ class UVCRemote(object):
             if camera['_id']:
                 cams_by_name_id[camera['name']] = camera['_id']
             cams_by_name_uuid[camera['name']] = camera['uuid']
-        if self.uuid_connection:
-            return cams_by_name_uuid.get(name)
-        else:
+        if self.id_connection:
             return cams_by_name_id.get(name)
+        else:
+            return cams_by_name_uuid.get(name)
+
 
 
     def get_camera(self, connection_id):
@@ -242,6 +243,7 @@ def get_auth_from_env():
     """
 
     combined = os.getenv('UVC')
+    connect_with_id = bool(os.getenv('UVC_CONNECT_WITH_ID'))
     if combined:
         # http://192.168.1.1:7080/apikey
         result = urlparse.urlparse(combined)
@@ -257,6 +259,5 @@ def get_auth_from_env():
         host = os.getenv('UVC_HOST')
         port = int(os.getenv('UVC_PORT', 7080))
         apikey = os.getenv('UVC_APIKEY')
-        connect_with_id = bool(os.getenv('UVC_CONNECT_WITH_ID'))
         path = '/'
     return host, port, apikey, path, connect_with_id

--- a/uvcclient/nvr.py
+++ b/uvcclient/nvr.py
@@ -51,10 +51,11 @@ class UVCRemote(object):
     """Remote control client for Ubiquiti Unifi Video NVR."""
     CHANNEL_NAMES = ['high', 'medium', 'low']
 
-    def __init__(self, host, port, apikey, path='/'):
+    def __init__(self, host, port, apikey, path='/', uuid_connection='true'):
         self._host = host
         self._port = port
         self._path = path
+        self.uuid_connection = uuid_connection
         if path != '/':
             raise Invalid('Path not supported yet')
         self._apikey = apikey
@@ -115,16 +116,16 @@ class UVCRemote(object):
         data = self._uvc_request('/api/2.0/camera/%s' % uuid)
         pprint.pprint(data)
 
-    def set_recordmode(self, uuid, mode, chan=None):
+    def set_recordmode(self, connection_id, mode, chan=None):
         """Set the recording mode for a camera by UUID.
 
-        :param uuid: Camera UUID
+        :param connection_id: Camera UUID or _id for connecting to camera
         :param mode: One of none, full, or motion
         :param chan: One of the values from CHANNEL_NAMES
         :returns: True if successful, False or None otherwise
         """
 
-        url = '/api/2.0/camera/%s' % uuid
+        url = '/api/2.0/camera/%s' % connection_id
         data = self._uvc_request(url)
         settings = data['data'][0]['recordingSettings']
         mode = mode.lower()
@@ -148,13 +149,13 @@ class UVCRemote(object):
         updated = data['data'][0]['recordingSettings']
         return settings == updated
 
-    def get_picture_settings(self, uuid):
-        url = '/api/2.0/camera/%s' % uuid
+    def get_picture_settings(self, connection_id):
+        url = '/api/2.0/camera/%s' % connection_id
         data = self._uvc_request(url)
         return data['data'][0]['ispSettings']
 
-    def set_picture_settings(self, uuid, settings):
-        url = '/api/2.0/camera/%s' % uuid
+    def set_picture_settings(self, connection_id, settings):
+        url = '/api/2.0/camera/%s' % connection_id
         data = self._uvc_request(url)
         for key in settings:
             dtype = type(data['data'][0]['ispSettings'][key])
@@ -166,14 +167,14 @@ class UVCRemote(object):
         data = self._uvc_request(url, 'PUT', json.dumps(data['data'][0]))
         return data['data'][0]['ispSettings']
 
-    def prune_zones(self, uuid):
-        url = '/api/2.0/camera/%s' % uuid
+    def prune_zones(self, connection_id):
+        url = '/api/2.0/camera/%s' % connection_id
         data = self._uvc_request(url)
         data['data'][0]['zones'] = [data['data'][0]['zones'][0]]
         self._uvc_request(url, 'PUT', json.dumps(data['data'][0]))
 
-    def list_zones(self, uuid):
-        url = '/api/2.0/camera/%s' % uuid
+    def list_zones(self, connection_id):
+        url = '/api/2.0/camera/%s' % connection_id
         data = self._uvc_request(url)
         return data['data'][0]['zones']
 
@@ -185,27 +186,38 @@ class UVCRemote(object):
         cams = self._uvc_request('/api/2.0/camera')['data']
         return [{'name': x['name'],
                  'uuid': x['uuid'],
+                 '_id':  x.get('_id',''),
                  'state': x['state'],
                  'managed': x['managed'],
              } for x in cams]
 
-    def name_to_uuid(self, name):
+    def name_to_connection_id(self, name):
         """Attempt to convert a camera name to its UUID.
 
         :param name: Camera name
         :returns: The UUID of the first camera with the same name if found,
                   otherwise None
         """
+        cams_by_name_id = {}
+        cams_by_name_uuid = {}
+
         cameras = self.index()
-        cams_by_name = {x['name']: x['uuid'] for x in cameras}
-        return cams_by_name.get(name)
+        for camera in cameras:
+            if camera['_id']:
+                cams_by_name_id[camera['name']] = camera['_id']
+            cams_by_name_uuid[camera['name']] = camera['uuid']
+        if self.uuid_connection:
+            return cams_by_name_uuid.get(name)
+        else:
+            return cams_by_name_id.get(name)
 
-    def get_camera(self, uuid):
-        return self._uvc_request('/api/2.0/camera/%s' % uuid)['data'][0]
 
-    def get_snapshot(self, uuid):
+    def get_camera(self, connection_id):
+        return self._uvc_request('/api/2.0/camera/%s' % connection_id)['data'][0]
+
+    def get_snapshot(self, connection_id):
         url = '/api/2.0/snapshot/camera/%s?force=true&apiKey=%s' % (
-            uuid, self._apikey)
+            connection_id, self._apikey)
         print(url)
         resp = self._safe_request('GET', url)
         if resp.status != 200:
@@ -245,5 +257,6 @@ def get_auth_from_env():
         host = os.getenv('UVC_HOST')
         port = int(os.getenv('UVC_PORT', 7080))
         apikey = os.getenv('UVC_APIKEY')
+        connect_with_id = bool(os.getenv('UVC_CONNECT_WITH_ID'))
         path = '/'
-    return host, port, apikey, path
+    return host, port, apikey, path, connect_with_id


### PR DESCRIPTION
The beta NVR software has an API change where `_id` is used instead of `uuid` to connect to camera's over the api. This PR introduces the option to pass a `id` flag and a flag that that allows a user to specify to use the connection id vs the uuid. 

After this is merged I will update the Homeassistant component configuration to allow for this flag. This will allow users like myself that use the NVR beta software to use homeassistant with our Cameras. 
